### PR TITLE
Deconstruct array input to allow passing duration

### DIFF
--- a/yeelight/yeelight.js
+++ b/yeelight/yeelight.js
@@ -75,7 +75,13 @@ module.exports = function(RED) {
             try {
                 var cmd = this.command
                 this.light = this.config ? this.config.light : null;
-                this.light[cmd](msg.payload).then(function(response) {
+                var send
+                if (Array.isArray(msg.payload)) {
+                    send = this.light[cmd](...msg.payload)
+                } else {
+                    send = this.light[cmd](msg.payload)
+                }
+                send.then(function(response) {
                     msg.payload = response;
                     node.send(msg);
                 });


### PR DESCRIPTION
https://lsong.org/node-yeelight/Yeelight.html#set_bright

I'd like to set a longer duration when changing the brightness in my scheduled automations. This would allow people to pass in an array like `[1,"smooth",10000]` to change brightness to 1% over 10 seconds. It would keep working normally for people who only pass a single value. The docs might also need updating to reflect this option.

I don't know how to test a forked node-red plugin, tested the changed code in a js playground.